### PR TITLE
Prettier integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-
 # eslint-config-phaistos-networks
 
 This package provides Phaistos Networks's .eslintrc as an extensible shared config.
 
-*It's basically a clone of [Airbnb's](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) same project with different and more rules and some other minor changes*
+_It's basically a clone of [Airbnb's](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) same project with different and more rules and some other minor changes_
 
 ### How to update
 
@@ -14,21 +13,21 @@ This package provides Phaistos Networks's .eslintrc as an extensible shared conf
 
 ## Usage
 
-We export three ESLint configurations for your usage.
+We export four ESLint configurations for your usage.
 
 ### eslint-config-phaistos-networks
 
 Our default export contains all of our ESLint rules, including EcmaScript 6+
 and React. It requires `eslint` and `eslint-plugin-react`.
 
-1. `npm install --save-dev eslint-config-phaistos-networks eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y eslint-plugin-react-hooks@next  babel-eslint eslint`
+1. `npm install --save-dev eslint-config-phaistos-networks eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y eslint-plugin-react-hooks@next babel-eslint eslint`
 2. add `"extends": "phaistos-networks"` to your .eslintrc
 
 ### eslint-config-phaistos-networks/base
 
 Lints ES6+ but does not lint React. Requires `eslint`.
 
-1. `npm install --save-dev eslint-config-phaistos-networks eslint-plugin-import babel-eslint eslint-plugin-react-hooks@next  eslint`
+1. `npm install --save-dev eslint-config-phaistos-networks eslint-plugin-import babel-eslint eslint-plugin-react-hooks@next eslint`
 2. add `"extends": "phaistos-networks/base"` to your .eslintrc
 
 ### eslint-config-phaistos-networks/legacy
@@ -38,8 +37,19 @@ Lints ES5 and below. Only requires `eslint`.
 1. `npm install --save-dev eslint-config-phaistos-networks eslint`
 2. add `"extends": "phaistos-networks/legacy"` to your .eslintrc
 
-### If you want to have eslint installed globally, i.e running eslint in terminal (CLI)
+### eslint-config-phaistos-networks/prettier
 
+Prettier is a high opinionated powerful automatic formatter. Eslinter is a code quality tool.
+They can both live together but there are some compromises we have to do. We should disable
+all the es-rules that are effecting the code formating and interfere with the prettier.
+
+The prettier setup contains the default export extended with the formating rules that interfere with the prettier.
+It requires `eslint` and `eslint-plugin-react`, as it is in the default configuration.
+
+1. `npm install --save-dev eslint-config-phaistos-networks eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y eslint-plugin-react-hooks@next babel-eslint eslint`
+2. add `"extends": "phaistos-networks/prettier"` to your .eslintrc
+
+### If you want to have eslint installed globally, i.e running eslint in terminal (CLI)
 
 ```bash
 npm install -g eslint
@@ -53,9 +63,7 @@ npm install -g eslint-config-phaistos-networks
 
 ### Additional notes
 
-+ Remove the args from yours sublimeLinter config so that the local `.eslintrc` as honored
-+ Make sure you add any additional rules and constants to .eslintrc that are specific to the project
-+ Make sure an `.eslintignore ` is in place so that you target your eslint where needed
-+ Run `eslint . --fix` when you have your eslint in place to fix those easy to fix errors
-
-
+- Remove the args from yours sublimeLinter config so that the local `.eslintrc` as honored
+- Make sure you add any additional rules and constants to .eslintrc that are specific to the project
+- Make sure an `.eslintignore` is in place so that you target your eslint where needed
+- Run `eslint . --fix` when you have your eslint in place to fix those easy to fix errors

--- a/prettier.js
+++ b/prettier.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: [
+    './base',
+    './rules/strict',
+    './rules/react',
+    './rules/prettier',
+  ].map(require.resolve),
+  rules: {}
+};

--- a/rules/prettier.js
+++ b/rules/prettier.js
@@ -1,0 +1,33 @@
+module.exports = {
+  rules: {
+    // http://eslint.org/docs/rules/newline-per-chained-call
+    "newline-per-chained-call": 0,
+
+    // enforce operators to be placed before or after line breaks
+    "operator-linebreak": ["error", "after"],
+
+    // require or disallow space before function opening parenthesis
+    // https://github.com/eslint/eslint/blob/master/docs/rules/space-before-function-paren.md
+    "space-before-function-paren": [
+      "error",
+      {
+        anonymous: "always",
+        named: "never",
+        asyncArrow: "always",
+      },
+    ],
+
+    // require immediate function invocation to be wrapped in parentheses
+    // http://eslint.org/docs/rules/wrap-iife.html
+    "wrap-iife": ["error", "inside"],
+
+    // Limit maximum of props on a single line in JSX
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
+    "react/jsx-max-props-per-line": 0,
+
+    "react/jsx-closing-bracket-location": [
+      1,
+      { selfClosing: "line-aligned", nonEmpty: "after-props" },
+    ]
+  }
+};

--- a/rules/react.js
+++ b/rules/react.js
@@ -185,7 +185,7 @@ module.exports = {
     'react/prefer-stateless-function': ERROR,
     // Prevent missing props validation in a React component definition
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
-    'react/prop-types': [WARN, { 'ignore': [], 'customValidators': [] }],
+    "react/prop-types": 0,
     // Prevent missing React when using JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
     'react/react-in-jsx-scope': ERROR,
@@ -270,7 +270,7 @@ module.exports = {
 
     // https://www.npmjs.com/package/eslint-plugin-react-hooks
     'react-hooks/rules-of-hooks': ERROR,
-    'react-hooks/exhaustive-deps': WARN,
+    'react-hooks/exhaustive-deps': OFF,
 
     'react/no-typos': 'error',
 

--- a/rules/style.js
+++ b/rules/style.js
@@ -8,7 +8,7 @@ module.exports = {
     camelcase: [
       2,
       {
-        properties: "always",
+        properties: "never",
         allow: ["^UNSAFE_"],
       },
     ],


### PR DESCRIPTION
In theory, Prettier is a high opinionated powerful automatic formatter. Eslinter is a code quality tool.
I did some investigation, on our eslint rules and the interference parts with the prettier.
We decided to use both prettier and eslint so we have to make some compromises.
We should disable all the es-rules that are effecting the code formating and interfere with the prettier. Eslint should live with the quality rules and prettier with the formating rules.

We introduce a fourth configuration, the `phaistos-networks/prettier`