### PR TITLE
fix(js): linebreak operator interpolates with prettier

### DIFF
--- a/rules/prettier.js
+++ b/rules/prettier.js
@@ -4,7 +4,7 @@ module.exports = {
     "newline-per-chained-call": 0,
 
     // enforce operators to be placed before or after line breaks
-    "operator-linebreak": ["error", "after"],
+    "operator-linebreak": 0,
 
     // require or disallow space before function opening parenthesis
     // https://github.com/eslint/eslint/blob/master/docs/rules/space-before-function-paren.md
@@ -28,6 +28,6 @@ module.exports = {
     "react/jsx-closing-bracket-location": [
       1,
       { selfClosing: "line-aligned", nonEmpty: "after-props" },
-    ]
-  }
+    ],
+  },
 };


### PR DESCRIPTION
Prettier has some exceptions regarding the linebreak operators. For instance, the tertiary operator is aligned on the left. So, `eslint` cannot represent this behavior with a specific rule.

https://github.com/prettier/prettier/issues/3806#issuecomment-442587872

This issue came up here https://github.com/TheBestCo/bp-content/pull/986